### PR TITLE
enabled AT803X_PHY

### DIFF
--- a/recipes-kernel/linux/linux/defconfig
+++ b/recipes-kernel/linux/linux/defconfig
@@ -1105,7 +1105,7 @@ CONFIG_PHYLIB=y
 #
 # MII PHY device drivers
 #
-# CONFIG_AT803X_PHY is not set
+CONFIG_AT803X_PHY=y
 # CONFIG_AMD_PHY is not set
 CONFIG_MARVELL_PHY=y
 # CONFIG_DAVICOM_PHY is not set


### PR DESCRIPTION
The AT803X_PHY was added here:
https://github.com/ExorEmbedded/linux-us02/commit/fffe3af8bb602c50ebc101bef0461ae45699cc31
but the socfpga_defconfig file in the linux-us02 is not used by meta-exor-us02.
