### PR TITLE
Avoid deleting all zImage* files

### DIFF
--- a/recipes-kernel/linux/linux_3.10.bb
+++ b/recipes-kernel/linux/linux_3.10.bb
@@ -25,6 +25,8 @@ KERNEL_DEVICETREE_usom02 = "socfpga_cyclone5.dtb"
 
 DTB_OUTPUT = "arch/arm/boot/dts"
 
+KERNEL_REMOVE_DEPLOYED ?= "${KERNEL_IMAGETYPE} *.dtb"
+
 do_deploy_append() {
    install -d "${DEPLOYDIR}"
    install -m 0644 "${B}/${KERNEL_OUTPUT}" "${DEPLOYDIR}"
@@ -36,8 +38,7 @@ do_deploy_append() {
    mv ${KERNEL_DEVICETREE} socfpga.dtb
    tar czvf "us02-kernel.tar.gz" "${KERNEL_IMAGETYPE}" socfpga.dtb
 
-   rm -rf  ${KERNEL_IMAGETYPE}*
-   rm -rf *.dtb
+   rm -rf ${KERNEL_REMOVE_DEPLOYED}
 }
 
 RDEPENDS_kernel-base = ""


### PR DESCRIPTION
Building kernel with bundled initramfs is not possible when this recipe deletes all zImage\* files. 
Files to delete from the DEPLOYDIR can now also be controlled from a bbappend file to this recipe by setting KERNEL_REMOVE_DEPLOYED.
