### PR TITLE
fix warnings on Yocto jethro

### DIFF
--- a/recipes-kernel/linux/linux_3.10.bb
+++ b/recipes-kernel/linux/linux_3.10.bb
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS := "${THISDIR}/${PN}-${KERNEL_VERSION}"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${KERNEL_VERSION}:"
 
 SRC_URI = "git://github.com/ExorEmbedded/linux-us02.git;protocol=git;branch=3.10-LTS;nocheckout=1"
 SRC_URI[md5sum] = "7094df7dedb134fa41ee6679a34de190"

--- a/recipes-kernel/linux/linux_4.1.bb
+++ b/recipes-kernel/linux/linux_4.1.bb
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS := "${THISDIR}/${PN}-${KERNEL_VERSION}"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${KERNEL_VERSION}:"
 
 SRC_URI = "git://github.com/ExorEmbedded/linux-us02.git;protocol=git;branch=4.1-LTS"
 SRC_URI[md5sum] = "7094df7dedb134fa41ee6679a34de190"


### PR DESCRIPTION
FILESEXTRAPATHS should only be used with _prepend or _append.
